### PR TITLE
Fixed Spelling for Epic Title - Task Assignment

### DIFF
--- a/documentation/theme_2/initiative_1/epics/epic_assign_task.md
+++ b/documentation/theme_2/initiative_1/epics/epic_assign_task.md
@@ -1,4 +1,4 @@
-# Epic: Task Assingment
+# Epic: Task Assignment
 
 ## Description
 Task assignment helps the team know who is responsible for which feature, bugfix, or etc.

--- a/documentation/theme_2/initiative_1/initiative_kanban_board.md
+++ b/documentation/theme_2/initiative_1/initiative_kanban_board.md
@@ -5,5 +5,5 @@ We want to use a Kanban Board to track of the progress of the project. A Kanban 
 who is responsible for each task.
 
 ## Epics
-* [Task Assingment](epics/epic_assign_task.md)
+* [Task Assignment](epics/epic_assign_task.md)
 * [Code Review](epics/epic_code_review.md)


### PR DESCRIPTION
Fixed spelling for an epic title called task assignment.